### PR TITLE
Fix arm IK circle color on dark mode

### DIFF
--- a/lib/src/pages/arm.dart
+++ b/lib/src/pages/arm.dart
@@ -60,9 +60,12 @@ class ArmPainterTop extends CustomPainter {
 class ArmPainterSide extends CustomPainter {
   /// The view model to pull data from.
   ArmModel model;
+
+  /// Color to paint the radius in
+  Color radiusColor;
   
   /// Constructor for the ArmPainterSide, takes in 3 angles
-  ArmPainterSide(this.model);
+  ArmPainterSide(this.model, this.radiusColor);
 
   /// The smaller screen dimension.
   late double screen;
@@ -120,7 +123,7 @@ class ArmPainterSide extends CustomPainter {
         paintArm(canvas, size, ikCoordinates, opacity: 0.5);
       }
       final radiusPaint = Paint()
-        ..color = Colors.black
+        ..color = radiusColor
         ..style = PaintingStyle.stroke
         ..strokeWidth = 2;
       final radius1 = length * (shoulderLength + elbowLength);
@@ -252,7 +255,7 @@ class ArmPage extends ReactiveWidget<ArmModel> {
             child: GestureDetector(
               onTap: model.sendIK,
               child: CustomPaint(
-                painter: ArmPainterSide(model),
+                painter: ArmPainterSide(model, context.colorScheme.onSurface),
               ),
             ),
           ),


### PR DESCRIPTION
On dark mode the radius circle for the arm viewer will be white instead of black making it more visible