### PR TITLE
Switch from fl_chart to syncfusion for graphs

### DIFF
--- a/lib/src/pages/electrical.dart
+++ b/lib/src/pages/electrical.dart
@@ -32,7 +32,7 @@ class _LineChart extends StatelessWidget {
       result.add(
         LineSeries(
           animationDuration: 0,
-          dataLabelMapper: (datum, index) => "${datum.value}$sideUnitName",
+          dataLabelMapper: (datum, index) => "${datum.value} $sideUnitName",
           color: colors[i],
           xValueMapper: (datum, index) => datum.time / 1000,
           yValueMapper: (datum, index) => datum.value,
@@ -58,7 +58,7 @@ class _LineChart extends StatelessWidget {
         name: sideUnitName,
         minimum: minY,
         maximum: maxY,
-        labelFormat: "{value}$sideUnitName",
+        labelFormat: "{value} $sideUnitName",
       ),
       series: getChartSeries(),
       tooltipBehavior: TooltipBehavior(enable: true, animationDuration: 0),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.2.0"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.19.0"
   json_annotation:
     dependency: transitive
     description:
@@ -550,6 +558,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  syncfusion_flutter_charts:
+    dependency: "direct main"
+    description:
+      name: syncfusion_flutter_charts
+      sha256: f1463e08decdae2fff4c67f0cd86bcd64050bc49ae50c2db18acd99fdc04da18
+      url: "https://pub.dev"
+    source: hosted
+    version: "27.1.51"
+  syncfusion_flutter_core:
+    dependency: transitive
+    description:
+      name: syncfusion_flutter_core
+      sha256: "95a53df168fd4473bbf23c481db656db97434d18d60f59fbeec97a754794f7b5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "27.1.51"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   just_audio: ^0.9.36
   collection: ^1.18.0
   sdl_gamepad: ^1.0.1
+  syncfusion_flutter_charts: ^27.1.51
 
 # Prefer to use `flutter pub add --dev packageName` rather than modify this section by hand.
 dev_dependencies:


### PR DESCRIPTION
This will fix the memory leak issue with pages that have graphs on them. Syncfusion graphs don't look as pretty but are much more efficient

![image](https://github.com/user-attachments/assets/3df73b13-b6ed-47b1-9b82-dc519397240b)
