### PR TITLE
Added keyboard shortcuts

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,9 +1,9 @@
-/// Defines any global app configuration. 
-/// 
+/// Defines any global app configuration.
+///
 /// Usually this page is reserved for theming, navigation, and startup logic.
-/// 
-/// This library is the final touch that ties the app together, so it may depend on any other 
-/// library (except for main.dart).  
+///
+/// This library is the final touch that ties the app together, so it may depend on any other
+/// library (except for main.dart).
 library app;
 
 import "package:flutter/material.dart";
@@ -11,10 +11,12 @@ import "package:rover_dashboard/models.dart";
 import "package:rover_dashboard/pages.dart";
 import "package:rover_dashboard/widgets.dart";
 
+import "shortcuts.dart";
+
 /// The classic Binghamton green.
 const binghamtonGreen = Color(0xff005943);
 
-/// The main class for the app. 
+/// The main class for the app.
 class RoverControlDashboard extends ReusableReactiveWidget<SettingsModel> {
   /// Creates the main app.
   RoverControlDashboard() : super(models.settings);
@@ -25,6 +27,7 @@ class RoverControlDashboard extends ReusableReactiveWidget<SettingsModel> {
     home: SplashPage(),
     debugShowCheckedModeBanner: false,
     themeMode: models.isReady ? model.dashboard.themeMode : ThemeMode.system,
+    shortcuts: shortcuts,
     theme: ThemeData(
       useMaterial3: false,
       colorScheme: const ColorScheme.light(

--- a/lib/models.dart
+++ b/lib/models.dart
@@ -35,6 +35,7 @@ export "src/models/data/views.dart";
 // Rover models
 export "src/models/rover/controller.dart";
 export "src/models/rover/controls/controls.dart";
+export "src/models/rover/keyboard_controller.dart";
 export "src/models/rover/metrics.dart";
 export "src/models/rover/rover.dart";
 

--- a/lib/shortcuts.dart
+++ b/lib/shortcuts.dart
@@ -1,0 +1,27 @@
+import "package:flutter/material.dart";
+import "package:flutter/services.dart";
+
+import "package:rover_dashboard/data.dart";
+import "package:rover_dashboard/models.dart";
+
+/// The global mapping of keyboard shortcuts.
+///
+/// Do not include rover controls in here. See [KeyboardController] instead
+final shortcuts = <ShortcutActivator, Intent>{
+  ...WidgetsApp.defaultShortcuts,
+  const SingleActivator(LogicalKeyboardKey.space): const VoidCallbackIntent(stopEverything),
+  const CharacterActivator("n"): VoidCallbackIntent(models.sockets.reset),
+  const CharacterActivator("l"): VoidCallbackIntent(models.sockets.toggleRoverType),
+};
+
+/// Sends all available stop commands and puts the rover into idle mode.
+void stopEverything() {
+  for (final controller in models.rover.controllers) {
+    for (final stopCommand in controller.controls.onDispose) {
+      models.messages.sendMessage(stopCommand);
+    }
+  }
+  models.rover.settings.setStatus(RoverStatus.IDLE);
+  models.sockets.autonomy.sendMessage(AutonomyCommand(abort: true));
+  models.home.setMessage(severity: Severity.error, text: "Stopped everything");
+}

--- a/lib/src/data/settings.dart
+++ b/lib/src/data/settings.dart
@@ -250,6 +250,9 @@ class DashboardSettings {
   /// The default preset to load on startup
   String? defaultPreset;
 
+  /// Whether the user should be able to drive via the keyboard.
+  final bool enableKeyboardShortcuts;
+
   /// A const constructor.
   DashboardSettings({
     required this.splitMode,
@@ -261,6 +264,7 @@ class DashboardSettings {
     required this.versionChecking,
     required this.presets,
     required this.defaultPreset,
+    required this.enableKeyboardShortcuts,
   });
 
   /// Parses settings from JSON.
@@ -276,6 +280,7 @@ class DashboardSettings {
     splitCameras = json?["splitCameras"] ?? false,
     preferTankControls = json?["preferTankControls"] ?? false,
     versionChecking = json?["versionChecking"] ?? true,
+    enableKeyboardShortcuts = json?["enableKeyboardShortcuts"] ?? false,
     themeMode = ThemeMode.values.byName(json?["theme"] ?? ThemeMode.system.name);
 
   /// Serializes these settings to JSON.
@@ -289,6 +294,7 @@ class DashboardSettings {
     "versionChecking": versionChecking,
     "presets": presets,
     "defaultPreset": defaultPreset,
+    "enableKeyboardShortcuts": enableKeyboardShortcuts,
   };
 }
 

--- a/lib/src/models/data/sockets.dart
+++ b/lib/src/models/data/sockets.dart
@@ -104,13 +104,26 @@ class Sockets extends Model {
   ///
   /// When working with localhost, even UDP sockets can throw errors when the remote is unreachable.
   /// Resetting the sockets will bypass these errors.
-  Future<void> reset() async {
+  Future<void> reset({bool shouldLog = true}) async {
     for (final socket in sockets) {
       await socket.dispose();
       await socket.init();
     }
     // Sockets lose their destination when disposed, so we restore it.
     await updateSockets();
+    if (shouldLog) {
+      models.home.setMessage(severity: Severity.info, text: "Network reset");
+    }
+  }
+
+  /// Toggles the network connection type.
+  void toggleRoverType() {
+    final newRoverType = switch(rover) {
+      RoverType.localhost => RoverType.rover,
+      RoverType.rover => RoverType.localhost,
+      RoverType.tank => RoverType.rover,
+    };
+    setRover(newRoverType);
   }
 
   /// Change which rover is being used.
@@ -118,7 +131,7 @@ class Sockets extends Model {
     if (value == null) return;
     rover = value;
     models.home.setMessage(severity: Severity.info, text: "Using: ${rover.name}");
-    await reset();
+    await reset(shouldLog: false);
     notifyListeners();
   }
 }

--- a/lib/src/models/rover/controller.dart
+++ b/lib/src/models/rover/controller.dart
@@ -72,6 +72,7 @@ class Controller extends Model {
     controls = RoverControls.forMode(mode);
     gamepad.pulse();
     notifyListeners();
+    models.rover.controllerModes.update();
   }
 
   /// Connects the [gamepad] to the user's device.
@@ -83,6 +84,7 @@ class Controller extends Model {
       models.home.setMessage(severity: Severity.error, text: "No gamepad connected");
     }
     notifyListeners();
+    models.rover.controllerModes.update();
   }
 
   /// Same as [setMode], but uses [OperatingMode.index] instead.

--- a/lib/src/models/rover/keyboard_controller.dart
+++ b/lib/src/models/rover/keyboard_controller.dart
@@ -1,0 +1,103 @@
+import "dart:async";
+
+import "package:flutter/services.dart";
+import "package:rover_dashboard/data.dart";
+import "package:rover_dashboard/models.dart";
+
+/// A model that sends [DriveCommand]s based on keyboard inputs.
+///
+/// This model cannot be refactored to use the standard Flutter keyboard shortcuts API since it
+/// depends on detecting [KeyUpEvent]s, which are not dispatched as shortcut events.
+///
+/// This class enables basic WASD control and up/down arrows for throttle.
+class KeyboardController extends Model {
+  static const _readInterval = Duration(milliseconds: 100);
+  static const _driveModes = {OperatingMode.drive, OperatingMode.modernDrive};
+
+  Timer? _inputTimer;
+
+  /// Whether the user is able to use these controls
+  bool get _isEnabled => _inputTimer != null;
+
+  bool get _shouldEnable => models.settings.dashboard.enableKeyboardShortcuts;
+
+  @override
+  Future<void> init() async {
+    if (models.settings.dashboard.enableKeyboardShortcuts) _startListening();
+    models.settings.addListener(_onUpdateSettings);
+    models.rover.controllerModes.addListener(_onControlsUpdated);
+    _onControlsUpdated();  // handle the on launch case
+  }
+
+  /// Whether any controller has control of the drive. Controllers take priority.
+  bool get _controllerHasDrive => models.rover.controllers
+    .any((controller) => controller.isConnected && _driveModes.contains(controller.mode));
+
+  void _onControlsUpdated() {
+    if (_isEnabled && _controllerHasDrive) {
+      _stopListening();
+    } else if (_shouldEnable && !_isEnabled && !_controllerHasDrive) {
+      _startListening();
+    }
+  }
+
+  void _onUpdateSettings() {
+    if (_shouldEnable && !_isEnabled) {
+      _startListening();
+    } else if (!_shouldEnable && _isEnabled) {
+      _stopListening();
+    }
+  }
+
+  void _startListening() {
+    HardwareKeyboard.instance.addHandler(_handleKeyboardEvents);
+    _inputTimer = Timer.periodic(_readInterval, _sendCommands);
+    notifyListeners();
+  }
+
+  void _stopListening() {
+    HardwareKeyboard.instance.removeHandler(_handleKeyboardEvents);
+    _inputTimer?.cancel();
+    _inputTimer = null;
+    notifyListeners();
+  }
+
+  bool _handleKeyboardEvents(KeyEvent event) {
+    final isReleased = event is KeyUpEvent;
+    switch (event.logicalKey) {  // speed and direction
+      case LogicalKeyboardKey.keyA: _direction = isReleased ? 0 :  0.5;
+      case LogicalKeyboardKey.keyD: _direction = isReleased ? 0 : -0.5;
+      case LogicalKeyboardKey.keyW: _speed = isReleased ? 0 :  0.5;
+      case LogicalKeyboardKey.keyS: _speed = isReleased ? 0 : -0.5;
+      case LogicalKeyboardKey.arrowUp:
+        if (isReleased) break;
+        _throttle = (_throttle + 0.1).clamp(0, 1);
+      case LogicalKeyboardKey.arrowDown:
+        if (isReleased) break;
+        _throttle = (_throttle - 0.1).clamp(0, 1);
+    }
+    return true;
+  }
+
+  void _sendCommands(_) {
+    final (left, right) = ModernDriveControls.getWheelSpeeds(_speed, _direction * 20);
+    models.messages.sendMessage(DriveCommand(setLeft: true, left: left));
+    models.messages.sendMessage(DriveCommand(setRight: true, right: right));
+    models.messages.sendMessage(DriveCommand(setThrottle: true, throttle: _throttle));
+  }
+
+  double _speed = 0;
+  double _direction = 0;
+  double _throttle = 0;
+
+  /// A description of which buttons are mapped to which functions.
+  Map<String, String> get buttonMapping => {
+    if (_isEnabled) ...{
+      "Drive": "WASD",
+      "Change throttle": "Arrow keys",
+    },
+    "Reset the network": "N",
+    "Toggle localhost mode": "L",
+    "Stop immediately": "Space",
+  };
+}

--- a/lib/src/models/rover/rover.dart
+++ b/lib/src/models/rover/rover.dart
@@ -6,8 +6,14 @@ import "package:rover_dashboard/models.dart";
 
 import "settings.dart";
 
+/// A model that updates whenever any controller changes mode or connection.
+class ControllerModes with ChangeNotifier {
+  /// Notifies that one of the controllers has changed modes.
+  void update() => notifyListeners();
+}
+
 /// The model to control the entire rover.
-/// 
+///
 /// Find more specific functionality in this class's fields.
 class Rover extends Model {
 	/// Monitors metrics coming from the rover.
@@ -24,6 +30,12 @@ class Rover extends Model {
 
   /// Listens for inputs on the third connected gamepad.
 	final controller3 = Controller(2, NoControls());
+
+  /// Listens for changes to any controller.
+  final controllerModes = ControllerModes();
+
+  /// Listens for inputs on the keyboard.
+  final keyboardController = KeyboardController();
 
   /// Sets all the gamepads to their default controls.
   void setDefaultControls() {
@@ -47,13 +59,14 @@ class Rover extends Model {
 	ValueNotifier<RoverStatus> status = ValueNotifier(RoverStatus.DISCONNECTED);
 
 	@override
-	Future<void> init() async { 
+	Future<void> init() async {
     setDefaultControls();
     await metrics.init();
 		await controller1.init();
 		await controller2.init();
     await controller3.init();
 		await settings.init();
+    await keyboardController.init();
 
 		metrics.addListener(notifyListeners);
 		settings.addListener(notifyListeners);
@@ -69,6 +82,7 @@ class Rover extends Model {
 		controller2.dispose();
     controller3.dispose();
 		settings.dispose();
+    keyboardController.dispose();
 		super.dispose();
 	}
 }

--- a/lib/src/models/view/builders/settings_builder.dart
+++ b/lib/src/models/view/builders/settings_builder.dart
@@ -205,6 +205,9 @@ class DashboardSettingsBuilder extends ValueBuilder<DashboardSettings> {
   /// The default preset to load on startup
   String? defaultPreset;
 
+  /// Whether to drive using the keyboard.
+  bool enableKeyboardShortcuts;
+
 	/// Modifies the given [DashboardSettings].
   DashboardSettingsBuilder(DashboardSettings initial) :
 		fps = NumberBuilder(initial.maxFps),
@@ -215,6 +218,7 @@ class DashboardSettingsBuilder extends ValueBuilder<DashboardSettings> {
     versionChecking = initial.versionChecking,
     themeMode = initial.themeMode,
     preset = initial.presets,
+    enableKeyboardShortcuts = initial.enableKeyboardShortcuts,
     defaultPreset = initial.defaultPreset;
 
   @override
@@ -231,6 +235,7 @@ class DashboardSettingsBuilder extends ValueBuilder<DashboardSettings> {
     versionChecking: versionChecking,
     presets: preset,
     defaultPreset: defaultPreset,
+    enableKeyboardShortcuts: enableKeyboardShortcuts,
   );
 
   /// Updates the [themeMode].
@@ -258,6 +263,12 @@ class DashboardSettingsBuilder extends ValueBuilder<DashboardSettings> {
   void updateVersionChecking(bool? input){ // ignore: avoid_positional_boolean_parameters
     if (input == null) return;
     versionChecking = input;
+    notifyListeners();
+  }
+
+  /// Updates [enableKeyboardShortcuts].
+  void updateKeyboardShortcuts(bool input) {  // ignore: avoid_positional_boolean_parameters
+    enableKeyboardShortcuts = input;
     notifyListeners();
   }
 }

--- a/lib/src/models/view/footer.dart
+++ b/lib/src/models/view/footer.dart
@@ -53,8 +53,5 @@ class FooterViewModel with ChangeNotifier {
   String get connectionSummary => models.sockets.connectionSummary;
 
   /// Resets the network sockets.
-  Future<void> resetNetwork() async {
-    await models.sockets.reset();
-    models.home.setMessage(severity: Severity.info, text: "Network reset");
-  }
+  Future<void> resetNetwork() => models.sockets.reset();
 }

--- a/lib/src/pages/settings.dart
+++ b/lib/src/pages/settings.dart
@@ -146,6 +146,12 @@ class SettingsPage extends ReactiveWidget<SettingsBuilder> {
                 onChanged: model.dashboard.updateTank,
               ),
               SwitchListTile(
+                title: const Text("Enable keyboard controls"),
+                subtitle: const Text("Allows basic controls through the keyboard"),
+                value: model.dashboard.enableKeyboardShortcuts,
+                onChanged: model.dashboard.updateKeyboardShortcuts,
+              ),
+              SwitchListTile(
                 title: const Text("Require version checking"),
                 subtitle: const Text("Default to version checking on"),
                 value: model.dashboard.versionChecking,

--- a/lib/src/services/gamepad/gamepad.dart
+++ b/lib/src/services/gamepad/gamepad.dart
@@ -1,7 +1,6 @@
-import "package:rover_dashboard/src/services/gamepad/mock.dart";
-
 import "state.dart";
 import "sdl.dart";
+import "mock.dart";
 
 import "../service.dart";
 

--- a/lib/src/widgets/navigation/sidebar.dart
+++ b/lib/src/widgets/navigation/sidebar.dart
@@ -45,18 +45,19 @@ class Sidebar extends StatelessWidget {
                         textAlign: TextAlign.center,
                       ),
                       const SizedBox(height: 4),
-                      ControlsDisplay(
+                      GamepadsControlsDisplay(
                         controller: models.rover.controller1,
                         gamepadNum: 1,
                       ),
-                      ControlsDisplay(
+                      GamepadsControlsDisplay(
                         controller: models.rover.controller2,
                         gamepadNum: 2,
                       ),
-                      ControlsDisplay(
+                      GamepadsControlsDisplay(
                         controller: models.rover.controller3,
                         gamepadNum: 3,
                       ),
+                      KeyboardControlsDisplay(),
                     ],
                   ),
                   Column(
@@ -121,19 +122,22 @@ extension SeverityUtil on Severity {
       };
 }
 
-/// Displays controls for the given [Controller].
-class ControlsDisplay extends ReusableReactiveWidget<Controller> {
-  /// The number gamepad being used.
-  final int gamepadNum;
+/// Shows a list of controls for an input.
+class ControlsDisplayBase extends StatelessWidget {
+  /// The controls and the buttons mapped to them.
+  final Map<String, String> controls;
 
-  /// A const constructor for this widget.
-  const ControlsDisplay({
-    required Controller controller,
-    required this.gamepadNum,
-  }) : super(controller);
+  /// The name of these controls.
+  final String name;
+
+  /// A widget to show a list of control.
+  const ControlsDisplayBase({
+    required this.controls,
+    required this.name,
+  });
 
   @override
-  Widget build(BuildContext context, Controller model) => ExpansionTile(
+  Widget build(BuildContext context) => ExpansionTile(
     expandedCrossAxisAlignment: CrossAxisAlignment.start,
     expandedAlignment: Alignment.centerLeft,
     childrenPadding: const EdgeInsets.symmetric(
@@ -141,12 +145,12 @@ class ControlsDisplay extends ReusableReactiveWidget<Controller> {
       vertical: 8,
     ),
     title: Text(
-      model.controls.mode.name,
+      name,
       style: Theme.of(context).textTheme.titleLarge,
       textAlign: TextAlign.start,
     ),
     children: [
-      for (final entry in model.controls.buttonMapping.entries) ...[
+      for (final entry in controls.entries) ...[
         Text(entry.key, style: Theme.of(context).textTheme.labelLarge),
         Text(
           "  ${entry.value}",
@@ -155,6 +159,37 @@ class ControlsDisplay extends ReusableReactiveWidget<Controller> {
       ],
     ],
   );
+}
+
+/// Displays controls for the given [Controller].
+class GamepadsControlsDisplay extends ReusableReactiveWidget<Controller> {
+  /// The number gamepad being used.
+  final int gamepadNum;
+
+  /// A const constructor for this widget.
+  const GamepadsControlsDisplay({
+    required Controller controller,
+    required this.gamepadNum,
+  }) : super(controller);
+
+  @override
+  Widget build(BuildContext context, Controller model) => ControlsDisplayBase(
+    name: "$gamepadNum. ${model.controls.mode.name}",
+    controls: model.controls.buttonMapping,
+  );
+}
+
+/// Displays controls for the [KeyboardController].
+///
+/// This needs to be reactive since the [KeyboardController.buttonMapping] will change
+/// depending on whether it is enabled.
+class KeyboardControlsDisplay extends ReusableReactiveWidget<KeyboardController> {
+  /// Starts listening to the [KeyboardController].
+  KeyboardControlsDisplay() : super(models.rover.keyboardController);
+
+  @override
+  Widget build(BuildContext context, KeyboardController model) =>
+    ControlsDisplayBase(controls: model.buttonMapping, name: "Keyboard controls");
 }
 
 /// A dropdown to select more or less views.


### PR DESCRIPTION
- Shortcuts: 
  - n to reset network
  - L to toggle between rover/localhost 
  - Space to stop everything
  - WASD + arrows to drive
- disable drive commands when a controller is in drive mode
- added a new setting to enable/disable keyboard controls

The standard shortcuts API is used for regular shortcuts, and a new `KeyboardController` class is used for the drive controls.