### PR TITLE
Cleanup handshakes and improve safety

### DIFF
--- a/lib/src/models/data/video.dart
+++ b/lib/src/models/data/video.dart
@@ -35,20 +35,12 @@ class VideoModel extends Model {
 	/// A timer to update the FPS counter.
 	late final Timer fpsTimer;
 
-	/// The latest handshake received by the rover.
-	VideoCommand? _handshake;
-
 	@override
 	Future<void> init() async {
 		models.messages.stream.onMessage<VideoData>(
 			name: VideoData().messageName,
 			constructor: VideoData.fromBuffer,
 			callback: handleData,
-		);
-		models.messages.stream.onMessage<VideoCommand>(
-			name: VideoCommand().messageName,
-			constructor: VideoCommand.fromBuffer,
-			callback: (command) => _handshake = command,
 		);
 		fpsTimer = Timer.periodic(const Duration(seconds: 1), resetNetworkFps);
 		reset();
@@ -117,12 +109,17 @@ class VideoModel extends Model {
 
 	/// Updates settings for the given camera.
 	Future<void> updateCamera(String id, CameraDetails details, {bool verify = true}) async {
-		_handshake = null;
 		final command = VideoCommand(id: id, details: details);
-		models.sockets.video.sendMessage(command);
-    if (!verify) return;
-		await Future<void>.delayed(const Duration(seconds: 2));
-		if (_handshake == null) throw RequestNotAccepted();
+    if (!verify) {
+      models.sockets.video.sendMessage(command);
+    } else {
+      final successful = await models.sockets.video.tryHandshake(
+        message: command,
+        timeout: const Duration(seconds: 2),
+        constructor: VideoCommand.fromBuffer,
+      );
+      if (!successful) throw RequestNotAccepted();
+    }
 	}
 
 	/// Enables or disables the given camera.
@@ -134,12 +131,14 @@ class VideoModel extends Model {
 		if (enable && details.status != CameraStatus.CAMERA_DISABLED) return;
 		if (!enable && details.status == CameraStatus.CAMERA_DISCONNECTED) return;
 
-		_handshake = null;
 		details.status = enable ? CameraStatus.CAMERA_ENABLED : CameraStatus.CAMERA_DISABLED;
 		final command = VideoCommand(id: feeds[name]!.id, details: details);
-		models.sockets.video.sendMessage(command);
-		await Future<void>.delayed(const Duration(seconds: 2));
-		if (_handshake == null) {
+    final successsful = await models.sockets.video.tryHandshake(
+      message: command,
+      timeout: const Duration(seconds: 2),
+      constructor: VideoCommand.fromBuffer,
+    );
+		if (!successsful) {
 			models.home.setMessage(
 				severity: Severity.warning,
 				text: "Could not ${enable ? 'enable' : 'disable'} the ${name.humanName} camera",

--- a/lib/src/models/rover/settings.dart
+++ b/lib/src/models/rover/settings.dart
@@ -17,28 +17,34 @@ class RoverSettings extends Model {
 	/// A shorthand for accessing [UpdateSetting.status].
 	RoverStatus get status => settings.status;
 
-	/// The last received confirmation from each socket.
-	int _handshakes = 0;
-
 	@override
-	Future<void> init() async {
-		models.messages.stream.onMessage(
-			name: UpdateSetting().messageName,
-			constructor: UpdateSetting.fromBuffer,
-			callback: (settings) => _handshakes++,
-		);
-	}
+	Future<void> init() async {}
 
 	/// Sends an [UpdateSetting] and awaits a response.
 	///
 	/// The response must be an echo of the data sent, to ensure the rover acknowledges the data.
 	/// Returns true if the handshake succeeds.
 	Future<bool> tryChangeSettings(UpdateSetting value) async {
-		_handshakes = 0;
-		models.sockets.data.sendMessage(value);
-		await Future<void>.delayed(confirmationDelay);
-		if (_handshakes != 3) {
-			models.home.setMessage(severity: Severity.error, text: "Could not update settings");
+    final expectedHandshakes =
+        models.sockets.sockets.where((socket) => socket.isConnected).map(
+              (socket) => socket.tryHandshake(
+                message: value,
+                timeout: confirmationDelay,
+                constructor: UpdateSetting.fromBuffer,
+              ),
+            );
+
+    if (expectedHandshakes.isEmpty) {
+      return true;
+    }
+
+    final receivedHandshakes = (await Future.wait(expectedHandshakes)).where((e) => e).length;
+
+		if (receivedHandshakes < expectedHandshakes.length) {
+      models.home.setMessage(
+        severity: Severity.error,
+        text: "Could not update settings, received $receivedHandshakes/${expectedHandshakes.length} handshakes",
+      );
 			return false;
 		}
 		return true;
@@ -48,24 +54,35 @@ class RoverSettings extends Model {
 	///
 	/// See [RoverStatus] for details.
 	Future<void> setStatus(RoverStatus value) async {
-    if (!models.rover.isConnected) return;
-    if (value == RoverStatus.AUTONOMOUS || value == RoverStatus.IDLE) {
+    if (!models.sockets.sockets.any((e) => e.isConnected)) return;
+    final message = UpdateSetting(status: value);
+    if (value != RoverStatus.MANUAL) {
       for (final controller in models.rover.controllers) {
         controller.setMode(OperatingMode.none);
       }
-    } else if (value == RoverStatus.MANUAL) {
-      models.rover.setDefaultControls();
-    } else {
-      final message = UpdateSetting(status: value);
-      models.sockets.video.sendMessage(message);
-      models.sockets.autonomy.sendMessage(message);
-      if (!await tryChangeSettings(message)) return;
     }
 
-    models.home.setMessage(severity: Severity.info, text: "Set mode to ${value.humanName}");
-		settings.status = value;
-		models.rover.status.value = value;
-		notifyListeners();
+    if (!await tryChangeSettings(message)) {
+      return;
+    }
+
+    if (value == RoverStatus.MANUAL) {
+      models.rover.setDefaultControls();
+    }
+
+    if (value == RoverStatus.RESTART) {
+      settings.status = RoverStatus.IDLE;
+      models.rover.status.value = RoverStatus.IDLE;
+
+      models.home.setMessage(severity: Severity.info, text: "Restarting sockets");
+    } else if (value != RoverStatus.POWER_OFF) {
+      settings.status = value;
+      models.rover.status.value = value;
+
+      models.home.setMessage(severity: Severity.info, text: "Set mode to ${value.humanName}");
+    }
+
+    notifyListeners();
 	}
 
 	/// Changes the color of the rover's LED strip.

--- a/lib/src/models/view/builders/autonomy_command.dart
+++ b/lib/src/models/view/builders/autonomy_command.dart
@@ -12,35 +12,14 @@ class AutonomyCommandBuilder extends ValueBuilder<AutonomyCommand> {
 	/// The view model to edit the [AutonomyCommand.destination].
 	final gps = GpsBuilder();
 
-	/// The handshake as received by the rover after [submit] is called.
-	AutonomyCommand? _handshake;
-
 	/// Whether the dashboard is awaiting a response from the rover.
 	bool isLoading = false;
 
-  /// A constructor to call [init] when created.
-	AutonomyCommandBuilder() { init(); }
+  /// A constructor for AutonomyCommandBuilder
+	AutonomyCommandBuilder();
 
   @override
   List<ChangeNotifier> get otherBuilders => [models.rover.status];
-
-  StreamSubscription<AutonomyCommand>? _subscription;
-
-	/// Listens for incoming confirmations from the rover that it received the command.
-  Future<void> init() async {
-    await Future<void>.delayed(const Duration(seconds: 1));
-		_subscription = models.messages.stream.onMessage(
-			name: AutonomyCommand().messageName,
-			constructor: AutonomyCommand.fromBuffer,
-			callback: (data) => _handshake = data,
-		);
-	}
-
-	@override
-	void dispose() {
-    _subscription?.cancel();
-		super.dispose();
-	}
 
 	@override
 	bool get isValid => gps.isValid;
@@ -59,13 +38,16 @@ class AutonomyCommandBuilder extends ValueBuilder<AutonomyCommand> {
 
 	/// Sends this command to the rover using [Sockets.autonomy].
 	Future<void> submit() async {
-		_handshake = null;
 		isLoading = true;
 		notifyListeners();
 		models.sockets.autonomy.sendMessage(value);
 		models.home.setMessage(severity: Severity.info, text: "Submitting autonomy command...");
 		await Future<void>.delayed(const Duration(seconds: 1));
-		if (_handshake != null) {
+    if (await models.sockets.autonomy.tryHandshake(
+      message: value,
+      timeout: const Duration(seconds: 1),
+      constructor: AutonomyCommand.fromBuffer,
+    )) {
 			models.home.setMessage(severity: Severity.info, text: "Command received");
 		} else {
 			models.home.setMessage(severity: Severity.error, text: "Command not received");
@@ -76,17 +58,18 @@ class AutonomyCommandBuilder extends ValueBuilder<AutonomyCommand> {
 
 	/// Forces the rover to go back to the previous waypoint.
 	Future<void> abort() async {
-		_handshake = null;
 		isLoading = true;
 		notifyListeners();
 		final message = AutonomyCommand(abort: true);
 		// x3 just in case
 		models.sockets.autonomy.sendMessage(message);
 		models.sockets.autonomy.sendMessage(message);
-		models.sockets.autonomy.sendMessage(message);
 		models.home.setMessage(severity: Severity.info, text: "Aborting...");
-		await Future<void>.delayed(const Duration(seconds: 1));
-		if (_handshake != null) {
+    if (await models.sockets.autonomy.tryHandshake(
+      message: message,
+      timeout: const Duration(seconds: 1),
+      constructor: AutonomyCommand.fromBuffer,
+    )) {
 			models.home.setMessage(severity: Severity.info, text: "Command received");
 		} else {
 			models.home.setMessage(severity: Severity.critical, text: "Command not received");

--- a/lib/src/services/socket.dart
+++ b/lib/src/services/socket.dart
@@ -24,7 +24,7 @@ class DashboardSocket extends BurtSocket {
   double get frequency => models.settings.network.connectionTimeout;
 
   /// Listens for incoming messages on a UDP socket and sends heartbeats to the [device].
-  DashboardSocket({required super.device}) : super(port: null, quiet: true);
+  DashboardSocket({required super.device}) : super(port: null, quiet: true, keepDestination: true);
 
   @override
   Duration get heartbeatInterval => Duration(milliseconds: 1000 ~/ frequency);


### PR DESCRIPTION
Cleaned up handshakes using the tryHandshake method

Also improve safety by not enabling controls until handshakes have been received for rover status updates